### PR TITLE
fix: render doc as part of book

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -5,9 +5,9 @@ book:
   title: "Bioinformatics Documentation"
   chapters:
     - index.qmd
-    - part: "Part_1"
+    - part: "Saga and NIRD usage"
       chapters:
-      - quarto_files/Part_1/dummy_document_1.qmd
+      - quarto_files/part_saga_nird/account_saga.qmd
     - part: "Part_2"
       chapters:
       - quarto_files/Part_2/dummy_document_2.qmd


### PR DESCRIPTION
for a qmd to be rendered as a part of a book (keep the styles, sidebar, etc. it need to be named in the _quarto.yml file